### PR TITLE
🚀 :label: Fix label casing in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Request a new feature
-labels: Feature
+labels: feature
 title: "[Feature]: "
 assignees:
  - Valentine195


### PR DESCRIPTION
The label casing in the feature request template has been fixed to match the convention used in the repository.