### PR TITLE
Add compare function to API

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "The ultimate Obsidian plugin for crafting mind-bending fantasy and sci-fi calendars",
     "main": "main.js",
     "scripts": {
-        "build": "node ./esbuild.config.mjs production && npm test",
+        "build": "node ./esbuild.config.mjs production && vitest --run",
         "dev": "node ./esbuild.config.mjs",
         "release-as": "scripty",
         "test": "vitest"

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,6 @@
 import type { Calendar, CalDate, CalEvent } from "src/@types";
 import { CalendarStore } from "src/stores/calendar.store";
+import { compareEvents } from "src/utils/functions";
 import { get } from "svelte/store";
 
 export class API {
@@ -32,8 +33,14 @@ export class API {
     getEvents(): CalEvent[] {
         return this.#store.eventStore.getEvents();
     }
+
     /** Get all events on a specific date. */
     getEventsOnDay(day: CalDate): CalEvent[] {
         return get(this.#store.eventStore.getEventsForDate(day));
+    }
+
+    /** Compare two events */
+    compareEvents(event1: CalEvent, event2: CalEvent): number {
+        return compareEvents(event1, event2);
     }
 }

--- a/src/settings/import/importer.ts
+++ b/src/settings/import/importer.ts
@@ -12,10 +12,10 @@ import type {
 import distinct from "distinct-colors";
 
 import { decode } from "he";
-import type { ImportedCalendar } from "src/@types/import";
+import type { ImportedCalendar } from "../../@types/import";
 import deepmerge from "deepmerge";
 import { DEFAULT_CALENDAR } from "../settings.constants";
-import { nanoid } from "src/utils/functions";
+import { nanoid } from "../../utils/functions";
 
 export default class Import {
     static import(objects: ImportedCalendar[]) {
@@ -82,7 +82,7 @@ export default class Import {
                     const intervals = interval.map((i) => {
                         const ignore = /\+/.test(i);
                         const exclusive = /\!/.test(i);
-                        const interval = i.match(/(\d+)/).first();
+                        const interval = i.match(/(\d+)/)[0];
 
                         return {
                             ignore,

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -187,12 +187,22 @@ export function areDatesEqual(date: CalDate, date2: CalDate) {
     return true;
 }
 
-export function sortEventList(list: CalEvent[]): CalEvent[] {
-    return list.sort((a, b) => {
-        if (!("sort" in a) || !("sort" in b)) return 0;
-        if (a.sort?.timestamp === b.sort?.timestamp) {
-            return a.sort?.order.localeCompare(b.sort?.order);
+export function compareEvents(a: CalEvent, b: CalEvent) {
+    if (a.sort && b.sort) {
+        if (a.sort.timestamp == b.sort.timestamp) {
+            return a.sort.order.localeCompare(b.sort.order);
         }
-        return a.sort?.timestamp - b.sort?.timestamp;
-    });
+        return a.sort.timestamp - b.sort.timestamp;
+    }
+    if (a.date.year != b.date.year) {
+        return a.date.year - b.date.year;
+    }
+    if (a.date.month != b.date.month) {
+        return a.date.month - b.date.month;
+    }
+    return a.date.day - b.date.day;
+}
+
+export function sortEventList(list: CalEvent[]): CalEvent[] {
+    return list.sort((a, b) => compareEvents(a, b));
 }


### PR DESCRIPTION
Surface a function that compares two calendar dates (for use when sorting arrays).

Three commits:

- Fix `build` (disable watch mode for vitest)
- Fix importer (update import path, remove .first)
- Add compareEvents method to API (wrapping a utility function pulled out from the previously existing sortEventList function).

BEGIN_COMMIT_OVERRIDE
feat: Adds compare function to API
END_COMMIT_OVERRIDE
