### PR TITLE
Add style settings for displaying span data

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { API } from "./api/api";
 import SettingsService from "./settings/settings.service";
 import { CalendarStore, createCalendarStore } from "./stores/calendar.store";
 import { CodeBlockService } from "./calendar/codeblock";
-import {/* 
+import {/*
     EVENT_LINKED_TO_NOTE,
     EVENT_LINKED_TO_NOTE_ICON, */
     REVEAL_ICON,
@@ -25,6 +25,7 @@ declare module "obsidian" {
         };
     }
     interface Workspace {
+        trigger(name: "parse-style-settings"): void; // trigger style settings
         on(name: "calendarium-updated", callback: () => any): EventRef;
         on(
             name: "calendarium-event-update",
@@ -174,6 +175,8 @@ export default class Calendarium extends Plugin {
 
             this.addCalendarView(true);
         });
+
+        app.workspace.trigger("parse-style-settings")
     }
 
     async onunload() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,2 +1,50 @@
 @import "./main.css";
 @import "./settings/settings.css";
+/*! @settings
+
+name: Calendarium Style settings
+id: calendarium-settings
+settings:
+  -
+    id: calendarium-nix-spans
+    title: Hide Calendarium date span attributes
+    description: When true, this will hide the data-date and data-name attributes of div or span HTML elements (subsequent style settings will not apply).
+    type: class-toggle
+    default: false
+  -
+    id: calendarium-span-data-style
+    title: Font style for data-date and data-name fields
+    type: variable-select
+    default: italic
+    options:
+        - italic
+        - normal
+  -
+    id: calendarium-span-data-weight
+    title: Font weight for data-date and data-name fields
+    type: variable-number-slider
+    default: 500
+    min: 100
+    max: 900
+    step: 50
+*/
+body {
+  --calendarium-span-data-color: var(--text-accent);
+}
+body:not(.calendarium-nix-spans) span[data-date]:not(.hide-data),
+body:not(.calendarium-nix-spans) div[data-date]:not(.hide-data) {
+  font-style: var(--calendarium-span-data-style, italic);
+  font-weight: var(--calendarium-span-data-weight, 500);
+}
+body:not(.calendarium-nix-spans) span[data-date]:not([data-end]):not(.hide-data)::before,
+body:not(.calendarium-nix-spans) div[data-date]:not([data-end]):not(.hide-data)::before {
+  content: "🔖 " attr(data-date) ": " attr(data-name) ". ";
+  color: var(--calendarium-span-data-color, var(--text-accent));
+  font-weight: 500;
+}
+body:not(.calendarium-nix-spans) span[data-date][data-end]:not(.hide-data)::before,
+body:not(.calendarium-nix-spans) div[data-date][data-end]:not(.hide-data)::before {
+  content: "🔖 " attr(data-date) " to " attr(data-end) ": " attr(data-name) ". ";
+  color: var(--calendarium-span-data-color, var(--text-accent));
+  font-weight: 500;
+}


### PR DESCRIPTION
- Add CSS to display span data (data-date, data-end, data-name)
- Use style settings to suppress display of span data

```
- <span data-date='1496-Kythorn-17-00' data-category='npc' data-name="⚔️ Doom Raider Zhenterim arrive in Waterdeep">Yagra is hired as a bodyguard</span>
```

is rendered as: 

<img width="551" alt="image" src="https://github.com/javalent/the-calendarium/assets/808713/2dcd4600-8764-4387-aa99-b048afa1a9a9">

BEGIN_COMMIT_OVERRIDE
feat: Add style settings for displaying span data
END_COMMIT_OVERRIDE
