### PR TITLE
✨🐛  add date formatting to API

### DIFF
--- a/src/@types/calendar.d.ts
+++ b/src/@types/calendar.d.ts
@@ -39,6 +39,8 @@ export interface StaticCalendarData {
     incrementDay: boolean;
     useCustomYears?: boolean;
     years?: Year[];
+    padMonths?:number;
+    padDays?:number;
 }
 
 export interface CalDate {
@@ -69,6 +71,7 @@ export type DefinedDay = Day &
     };
 export type LeapDay = BaseDay & {
     type: "leapday";
+    short?: string; // akin to month
     interval: LeapDayCondition[];
     timespan: number;
     intercalary: boolean;
@@ -90,6 +93,7 @@ interface BaseMonth extends TimeSpan {
     offset: number;
     type: "month" | "intercalary";
     subtitle?: string;
+    short?: string;
 }
 export interface RegularMonth extends BaseMonth {
     type: "month";

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -16,7 +16,7 @@ export class API {
             store = this.plugin.getStoreByCalendar(calendar);
         }
         if (!store)
-            throw new ReferenceError("No calendar store by that name exists.");
+            throw new ReferenceError("No calendar by that name exists.");
         return store;
     }
     /**
@@ -27,8 +27,11 @@ export class API {
      * @returns An instance of the Calendar API.
      */
     getAPI(calendarName: string): CalendarAPI {
-        const store = this.#getStore(calendarName);
-        return new CalendarAPI(store);
+        const calendar = this.plugin.data.calendars.find((c) => c.name == calendarName);
+        if (!calendar)
+            throw new ReferenceError("No calendar store by that name exists.");
+        const store = this.#getStore(calendar);
+        return new CalendarAPI(store, calendar);
     }
     /**
      * Translate an event from one calendar to another.

--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -1,13 +1,14 @@
 import type { Calendar, CalDate, CalEvent } from "src/@types";
 import { CalendarStore } from "src/stores/calendar.store";
-import { compareEvents } from "src/utils/functions";
+import { compareEvents, dateString } from "src/utils/functions";
 import { get } from "svelte/store";
 
 export class CalendarAPI {
     #store: CalendarStore;
     #object: Calendar;
-    constructor(store: CalendarStore) {
+    constructor(store: CalendarStore, object: Calendar) {
         this.#store = store;
+        this.#object = object;
     }
 
     /**
@@ -50,5 +51,28 @@ export class CalendarAPI {
     /** Compare two events */
     compareEvents(event1: CalEvent, event2: CalEvent): number {
         return compareEvents(event1, event2);
+    }
+
+    /**
+     * Return a display string for an event.
+     *
+     * Use the following in your formatting string:
+     *
+     * - `Y` - any number of Y will bring the full year.
+     *     - If your calendar uses named years, you'll get the name.
+     * - `M` - the month as a number.
+     * - `MM` - the month as a number, zero padded, minimum of two digits.
+     * - `MMM` - the month name, abbreviated (if available).
+     * - `MMMM` - the full month name
+     * - `D` - the day of the month, unpadded.
+     * - `DD` - the day of the month, zero padded, minimum of two digits.
+     *
+     * @param date Date to convert to a formatted string
+     * @param end Optional end date for multi-day events
+     * @param dateFormat Optional date format string
+     * @returns formatted string
+     */
+    toDisplayDate(date: CalDate, end?: CalDate, dateFormat?: string): string {
+        return dateString(date, this.#object, end, dateFormat);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import SettingsService from "./settings/settings.service";
 import { CalendarStore, createCalendarStore } from "./stores/calendar.store";
 import { CodeBlockService } from "./calendar/codeblock";
 import {
+    DEFAULT_FORMAT,
     /*
     EVENT_LINKED_TO_NOTE,
     EVENT_LINKED_TO_NOTE_ICON, */
@@ -115,7 +116,7 @@ export default class Calendarium extends Plugin {
         return (
             (this.data.dailyNotes && this.canUseDailyNotes
                 ? this.dailyNotes.instance.options.format
-                : this.data.dateFormat) ?? "YYYY-MM-DD"
+                : this.data.dateFormat) ?? DEFAULT_FORMAT
         );
     }
     hasCalendar(calendar: string): boolean {
@@ -145,7 +146,7 @@ export default class Calendarium extends Plugin {
         /* addIcon(EVENT_LINKED_TO_NOTE, EVENT_LINKED_TO_NOTE_ICON); */
 
         this.watcher = new Watcher(this);
-        
+
         (window["Calendarium"] = this.api) &&
             this.register(() => delete window["Calendarium"]);
 

--- a/src/settings/creator/stores/calendar.ts
+++ b/src/settings/creator/stores/calendar.ts
@@ -22,6 +22,19 @@ import {
 } from "src/utils/functions";
 import { derived, writable } from "svelte/store";
 
+function padMonth(months: Month[]) {
+    return (months.length + "").length;
+}
+
+function padDay(months: Month[]) {
+    return (
+        months.reduce(
+            (max, month) => (max > month.length ? max : month.length),
+            0
+        ) + ""
+    ).length;
+}
+
 function createStore(
     plugin: Calendarium,
     existing: Calendar = DEFAULT_CALENDAR
@@ -38,6 +51,8 @@ function createStore(
     const staticSet = (data: StaticCalendarData) =>
         update((calendar) => {
             calendar.static = data;
+            calendar.static.padMonths = padMonth(calendar.static.months);
+            calendar.static.padDays = padDay(calendar.static.months);
             return calendar;
         });
 
@@ -196,6 +211,8 @@ function createStore(
                         interval: 1,
                         offset: 0,
                     });
+                    data.static.padMonths = padMonth(data.static.months);
+                    data.static.padDays = padDay(data.static.months);
                     return data;
                 }),
             update: (id: string, month: Month) =>
@@ -205,6 +222,8 @@ function createStore(
                         1,
                         month
                     );
+                    data.static.padMonths = padMonth(data.static.months);
+                    data.static.padDays = padDay(data.static.months);
                     return data;
                 }),
             delete: (id: string) =>
@@ -212,11 +231,15 @@ function createStore(
                     data.static.months = data.static.months.filter(
                         (m) => m.id != id
                     );
+                    data.static.padMonths = padMonth(data.static.months);
+                    data.static.padDays = padDay(data.static.months);
                     return data;
                 }),
             set: (months: Month[]) =>
                 update((data) => {
                     data.static.months = [...months];
+                    data.static.padMonths = padMonth(data.static.months);
+                    data.static.padDays = padDay(data.static.months);
                     return data;
                 }),
         },

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -1,11 +1,5 @@
-import type {
-    Calendar,
-    CalDate,
-    CalEvent,
-    LeapDay,
-    Month,
-    Day,
-} from "../@types";
+import type { Calendar, CalDate, CalEvent, Day, LeapDay, Nullable } from "../@types";
+import { DEFAULT_FORMAT } from "./constants";
 
 export function daysBetween(date1: Date, date2: Date) {
     const d1 = window.moment(date1);
@@ -85,66 +79,128 @@ export function ordinal(i: number) {
     }
     return i + "th";
 }
-export function dateString(date: CalDate, calendar: Calendar, end?: CalDate) {
+
+export function dateString(date: Partial<CalDate>, calendar: Calendar, end?: Partial<CalDate>, dateFormat?: string) {
     if (!date || date.day == undefined) {
         return "";
     }
+    if (!dateFormat) {
+        // default calendar format is DEFAULT_FORMAT (YYYY-MM-DD).. should this be flipped?
+        dateFormat = calendar.dateFormat || DEFAULT_FORMAT;
+    }
     const { day, month, year } = date;
-    let yearDisplay: string = `${year}`;
     const { months, years, useCustomYears } = calendar.static;
+
+    let startY: string = `${year}`;
     if (useCustomYears) {
-        yearDisplay = years[year - 1].name;
+        startY = years[year - 1].name;
     }
     if (month != undefined && !months[month]) return "Invalid Date";
+
+    const startM = month == undefined ? undefined : months[month].name;
+    const startD = ordinal(day);
 
     if (end && end.day) {
         const endDay = end.day;
         const endMonth = end.month;
         const endYear = end.year;
-        let endYearDisplay: string = `${endYear}`;
+        let endY: string = `${endYear}`;
         if (useCustomYears) {
-            endYearDisplay = years[endYear - 1]?.name;
+            endY = years[endYear - 1]?.name;
         }
+        const endM = endMonth == undefined ? endMonth : months[endMonth].name;
+        const endD = ordinal(endDay);
 
-        if (
-            endMonth != undefined &&
-            endYear != undefined &&
-            month != undefined &&
-            year != undefined
-        ) {
-            if (year != endYear) {
-                return `${months[month].name} ${ordinal(
-                    day
-                )}, ${yearDisplay} - ${months[endMonth].name} ${ordinal(
-                    endDay
-                )}, ${endYear}`;
-            }
-            if (endMonth == month) {
-                return `${months[month].name} ${ordinal(day)}-${ordinal(
-                    endDay
-                )}, ${yearDisplay}`;
-            }
-            if (month != undefined && year != undefined) {
-                return `${months[month].name} ${ordinal(day)}-${
-                    months[endMonth].name
-                } ${ordinal(endDay)}, ${yearDisplay}`;
-            }
-            if (month != undefined) {
-                return `${months[month].name} ${ordinal(day)}-${
-                    months[endMonth].name
-                } ${ordinal(endDay)} of every year`;
-            }
-            return `${ordinal(day)}-${ordinal(endDay)} of every month`;
+        // \u2014 is em dash
+        if (month != undefined && endMonth != undefined && year != undefined && year != endYear) {
+            const startStr = format(calendar, dateFormat, startY, date as CalDate);
+            const endStr = format(calendar, dateFormat, endY, end as CalDate);
+            return `${startStr} — ${endStr}`;
         }
+        if (month != undefined && endMonth != undefined && year != undefined && endMonth != month) {
+            return `${startM} ${startD} — ${endM} ${endD}, ${startY}`;
+        }
+        if (month != undefined && endMonth != undefined && year != undefined) {
+            return `${startM} ${startD}—${endD}, ${startY}`;
+        }
+        if (month != undefined && endMonth != undefined && endMonth != month) {
+            return `${startM} ${startD} — ${endM} ${endD} of every year`;
+        }
+        if (month != undefined && endMonth != undefined) {
+            return `${startM} ${startD}—${endD} of every year`;
+        }
+        return `${startD}—${endD} of every month`;
     }
 
     if (month != undefined && year != undefined) {
-        return `${months[month].name} ${ordinal(day)}, ${yearDisplay}`;
+        return format(calendar, dateFormat, startY, date as CalDate);
     }
     if (month != undefined) {
-        return `${months[month].name} ${ordinal(day)} of every year`;
+        return `${startM} ${startD} of every year`;
     }
-    return `${ordinal(day)} of every month`;
+    return `${startD} of every month`;
+}
+
+function format(calendar: Calendar, dateFormat: string, year: string|number, date: CalDate): string {
+    let format = dateFormat
+        .replace(/[Yy]+/g, '🂡')
+        .replace(/[Mm]{4,}/g, '🂢') // MMMM
+        .replace(/[Mm]{3,}/g, '🂣') // MMM
+        .replace(/[Mm]{2,}/g, '🂤') // MM
+        .replace(/[Mm]/g, '🂥')     // M
+        .replace(/[Dd]{2,}/g, '🂦')
+        .replace(/[Dd]/g, '🂧');
+
+    // If we have an intercalary month and are using "pretty names", well...
+    if (format.match(/🂢|🂣/g) && calendar.static.months[date.month].type == "intercalary") {
+        // It's an intercalary month with only one day? Remove the day.
+        if (calendar.static.months[date.month].length == 1 && date.day == 1) {
+            format = format
+                .replace(/^🂦|🂧[ -]/g, '') // day at the beginning
+                .replace(/[ -]🂦|🂧/g, ''); // day in the middle or end
+        } else {
+            const leapday = calendar.static.leapDays.find(
+                (l: LeapDay) => l.timespan == date.month
+            );
+            if (leapday && testLeapDay(leapday, date.year)) {
+                // It's a well-known intercalary leap day! Huzzah!
+                // Use that as the month name, and remove the day.
+                format = format
+                    .replace('🂢', leapday.name) // MMMM
+                    .replace('🂣', shorten(leapday.short, leapday.name)) // MMM
+                    .replace(/^🂦|🂧[ -]/g, '') // day at the beginning
+                    .replace(/[ -]🂦|🂧/g, ''); // day in the middle or end
+                }
+        }
+    }
+
+    return format
+        .replace('🂡', `${year}`)
+        .replace('🂢', toMonthString(date.month, calendar)) // MMMM
+        .replace('🂣', toShortMonthString(date.month, calendar)) // MMM
+        .replace('🂤', toPaddedString(date.month + 1, calendar, "month")) // to human index (intercalary?)
+        .replace('🂥', `${date.month + 1}`) // M
+        .replace('🂦', toPaddedString(date.day, calendar, "day"))
+        .replace('🂧', `${date.day}`)
+        .trim();
+}
+
+function shorten(short: string, name: string) {
+    return short ? short : name.slice(0, 3);
+}
+
+export function toMonthString(month: Nullable<number>, calendar: Calendar): string {
+    return month == null ? "*" : calendar.static.months[month].name;
+}
+
+export function toShortMonthString(month: Nullable<number>, calendar: Calendar): string {
+    return month == null ? "*"
+        : shorten(calendar.static.months[month].short, calendar.static.months[month].name);
+}
+
+export function toPaddedString(data: Nullable<number>, calendar: Calendar, field: string): string {
+    const padding = field == "month" ? calendar.static.padMonths : calendar.static.padDays;
+    return data == null ? "*" : String(data).padStart(padding, "0");
 }
 
 export function isValidDay(day: number, calendar: Calendar) {
@@ -175,6 +231,31 @@ export function isValidYear(year: number, calendar: Calendar) {
         if (year < 0 || year >= calendar?.static?.years?.length) return false;
     }
     return true;
+}
+
+/**
+ * Test if a leap day occurs in a given year.
+ */
+export function testLeapDay(leapday: LeapDay, year: number) {
+    return leapday.interval
+        .sort((a, b) => a.interval - b.interval)
+        .some(({ interval, exclusive }, index, array) => {
+            if (exclusive && index == 0) {
+                return (year - leapday.offset ?? 0) % interval != 0;
+            }
+
+            if (exclusive) return;
+
+            if (array[index + 1] && array[index + 1].exclusive) {
+                return (
+                    (year - leapday.offset ?? 0) % interval == 0 &&
+                    (year - leapday.offset ?? 0) %
+                        array[index + 1].interval !=
+                        0
+                );
+            }
+            return (year - leapday.offset ?? 0) % interval == 0;
+        });
 }
 
 export function areDatesEqual(date: CalDate, date2: CalDate) {

--- a/src/utils/presets.ts
+++ b/src/utils/presets.ts
@@ -217,6 +217,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
             ],
             offset: 0,
+            padDays: 2,
+            padMonths: 2
         },
         current: {
             year: null,
@@ -505,6 +507,8 @@ export const PRESET_CALENDARS: Calendar[] = [
             displayMoons: true,
             firstWeekDay: 0,
             overflow: false,
+            padDays: 2,
+            padMonths: 2,
             weekdays: [
                 {
                     type: "day",
@@ -1011,6 +1015,8 @@ export const PRESET_CALENDARS: Calendar[] = [
             incrementDay: false,
             displayMoons: true,
             overflow: true,
+            padDays: 2,
+            padMonths: 2,
             weekdays: [
                 {
                     type: "day",
@@ -2680,6 +2686,8 @@ export const PRESET_CALENDARS: Calendar[] = [
             incrementDay: false,
             displayMoons: true,
             overflow: false,
+            padDays: 2,
+            padMonths: 2,
             weekdays: [
                 {
                     type: "day",
@@ -3465,6 +3473,8 @@ export const PRESET_CALENDARS: Calendar[] = [
             incrementDay: false,
             displayMoons: true,
             overflow: true,
+            padDays: 2,
+            padMonths: 2,
             weekdays: [
                 {
                     type: "day",
@@ -3797,6 +3807,8 @@ export const PRESET_CALENDARS: Calendar[] = [
             incrementDay: false,
             displayMoons: true,
             overflow: true,
+            padDays: 2,
+            padMonths: 2,
             weekdays: [
                 {
                     type: "day",
@@ -4451,12 +4463,15 @@ export const PRESET_CALENDARS: Calendar[] = [
         path: ["/"],
         supportInlineEvents: false,
         inlineEventTag: "inline-events",
+        dateFormat: "YYYY-MMM-DD",
         static: {
             displayDayNumber: false,
             firstWeekDay: 0,
             incrementDay: false,
             displayMoons: true,
             overflow: false,
+            padDays: 2,
+            padMonths: 2,
             weekdays: [
                 {
                     type: "day",
@@ -4512,6 +4527,8 @@ export const PRESET_CALENDARS: Calendar[] = [
             months: [
                 {
                     name: "Hammer (Deepwinter)",
+                    short: "Hammer",
+                    subtitle: "Deepwinter",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4520,6 +4537,7 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Midwinter",
+                    short: "Midwinter",
                     type: "intercalary",
                     length: 1,
                     interval: 1,
@@ -4528,6 +4546,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Alturiak (The Claw of Winter)",
+                    short: "Alturiak",
+                    subtitle: "The Claw of Winter",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4536,6 +4556,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Ches (The Claw of the Sunsets)",
+                    short: "Ches",
+                    subtitle: "The Claw of the Sunsets",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4544,6 +4566,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Tarsakh (The Claw of Storms)",
+                    short: "Tarsakh",
+                    subtitle: "The Claw of Storms",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4552,6 +4576,7 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Greengrass",
+                    short: "Greengrass",
                     type: "intercalary",
                     length: 1,
                     interval: 1,
@@ -4560,6 +4585,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Mirtul (The Melting)",
+                    short: "Mirtul",
+                    subtitle: "The Melting",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4568,6 +4595,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Kythorn (The Time of Flowers)",
+                    short: "Kythorn",
+                    subtitle: "The Time of Flowers",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4576,6 +4605,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Flamerule (Summertide)",
+                    short: "Flamerule",
+                    subtitle: "Summertide",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4584,6 +4615,7 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Midsummer",
+                    short: "Midsummer",
                     type: "intercalary",
                     length: 1,
                     interval: 1,
@@ -4592,6 +4624,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Eleasis (Highsun)",
+                    short: "Eleasis",
+                    subtitle: "Highsun",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4600,6 +4634,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Eleint (The Fading)",
+                    short: "Eleint",
+                    subtitle: "The Fading",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4608,6 +4644,7 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Highharvestide",
+                    short: "Highharvestide",
                     type: "intercalary",
                     length: 1,
                     interval: 1,
@@ -4616,6 +4653,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Marpenoth (Leaffall)",
+                    short: "Marpenoth",
+                    subtitle: "Leaffall",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4624,6 +4663,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Uktar (The Rotting)",
+                    short: "Uktar",
+                    subtitle: "The Rotting",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4632,6 +4673,7 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "The Feast of the Moon",
+                    short: "FeastOfTheMoon",
                     type: "intercalary",
                     length: 1,
                     interval: 1,
@@ -4640,6 +4682,8 @@ export const PRESET_CALENDARS: Calendar[] = [
                 },
                 {
                     name: "Nightal (The Drawing Down)",
+                    short: "Nightal",
+                    subtitle: "The Drawing Down",
                     type: "month",
                     length: 30,
                     interval: 1,
@@ -4660,8 +4704,8 @@ export const PRESET_CALENDARS: Calendar[] = [
             leapDays: [
                 {
                     name: "Shieldmeet",
+                    short: "Shieldmeet",
                     type: "leapday",
-
                     interval: [
                         {
                             ignore: false,

--- a/test/event.parseAltFormat.test.ts
+++ b/test/event.parseAltFormat.test.ts
@@ -1,12 +1,13 @@
 /**
  * @vitest-environment happy-dom
  */
-import { CalEventDate } from "../src/@types";
+import { CalDate, CalEventDate } from "../src/@types";
 import { CalEventHelper } from "../src/events/event.helper";
 import { PRESET_CALENDARS } from "../src/utils/presets";
 import { test, expect } from "vitest";
 
 import Moment from "moment";
+import { dateString } from "../src/utils/functions";
 Object.defineProperty(window, "moment", { value: Moment });
 
 const GREGORIAN = PRESET_CALENDARS.find((p) => p.name == "Gregorian Calendar");
@@ -15,7 +16,7 @@ const file = {
     basename: "basename",
 };
 
-const input: CalEventDate = {
+const input: CalDate = {
     year: 1400,
     month: 1,
     day: 28,
@@ -25,7 +26,7 @@ test("YYYY-MM-DD", () => {
     const YMD = new CalEventHelper(GREGORIAN, true);
     const datestring = "1400-02-28";
     expect(YMD.formatDigest).toEqual("YMD");
-    expect(YMD.toCalDateString(input)).toEqual(datestring);
+    expect(dateString(input, GREGORIAN, undefined, "YYYY-MM-DD")).toEqual(datestring);
     expect(YMD.parseCalDateString(datestring, file)).toEqual(
         expect.objectContaining(input)
     );
@@ -35,7 +36,7 @@ test("YYYY-MMM-DD", () => {
     const YMD = new CalEventHelper(GREGORIAN, true);
     const datestring = "1400-February-28";
     expect(YMD.formatDigest).toEqual("YMD");
-    expect(YMD.toCalDateString(input)).toEqual(datestring);
+    expect(dateString(input, GREGORIAN, undefined, "YYYY-MMM-DD")).toEqual(datestring);
     expect(YMD.parseCalDateString(datestring, file)).toEqual(
         expect.objectContaining(input)
     );
@@ -46,7 +47,7 @@ test("M-D-Y", () => {
     const MDY = new CalEventHelper(GREGORIAN, true);
     const datestring = "2-28-1400";
     expect(MDY.formatDigest).toEqual("MDY");
-    expect(MDY.toCalDateString(input)).toEqual(datestring);
+    expect(dateString(input, GREGORIAN, undefined, "M-D-Y")).toEqual(datestring);
     expect(MDY.parseCalDateString(datestring, file)).toEqual(
         expect.objectContaining(input)
     );
@@ -57,7 +58,7 @@ test("MM-D-Y", () => {
     const MDY = new CalEventHelper(GREGORIAN, true);
     const datestring = "02-28-1400";
     expect(MDY.formatDigest).toEqual("MDY");
-    expect(MDY.toCalDateString(input)).toEqual(datestring);
+    expect(dateString(input, GREGORIAN, undefined, "MM-D-Y")).toEqual(datestring);
     expect(MDY.parseCalDateString(datestring, file)).toEqual(
         expect.objectContaining(input)
     );
@@ -68,7 +69,7 @@ test("DD-M-Y", () => {
     const DMY = new CalEventHelper(GREGORIAN, true);
     const datestring = "28-2-1400";
     expect(DMY.formatDigest).toEqual("DMY");
-    expect(DMY.toCalDateString(input)).toEqual(datestring);
+    expect(dateString(input, GREGORIAN, undefined, "DD-M-Y")).toEqual(datestring);
     expect(DMY.parseCalDateString(datestring, file)).toEqual(
         expect.objectContaining(input)
     );
@@ -79,8 +80,111 @@ test("DD-MMM-Y", () => {
     const DMY = new CalEventHelper(GREGORIAN, true);
     const datestring = "28-February-1400";
     expect(DMY.formatDigest).toEqual("DMY");
-    expect(DMY.toCalDateString(input)).toEqual(datestring);
+    expect(dateString(input, GREGORIAN, undefined, "DD-MMM-Y")).toEqual(datestring);
     expect(DMY.parseCalDateString(datestring, file)).toEqual(
         expect.objectContaining(input)
     );
+});
+
+test("Date Range: Different year", () => {
+    GREGORIAN.dateFormat = "DD-MMM-Y";
+    const DMY = new CalEventHelper(GREGORIAN, true);
+    const start: CalDate = {
+        year: 1400,
+        month: 1,
+        day: 28,
+    };
+    const end: CalDate = {
+        year: 1401,
+        month: 1,
+        day: 28,
+    };
+    expect(dateString(start, GREGORIAN, end, "DD-MMM-Y")).toEqual("28-February-1400 — 28-February-1401");
+});
+
+test("Date Range: Same year, different month", () => {
+    GREGORIAN.dateFormat = "DD-MMM-Y";
+    const DMY = new CalEventHelper(GREGORIAN, true);
+    const start: CalDate = {
+        year: 1400,
+        month: 1,
+        day: 28,
+    };
+    const end: CalDate = {
+        year: 1400,
+        month: 2,
+        day: 28,
+    };
+    expect(dateString(start, GREGORIAN, end, "DD-MMM-Y")).toEqual("February 28th — March 28th, 1400");
+});
+
+test("Date Range: Same month, different day", () => {
+    GREGORIAN.dateFormat = "DD-MMM-Y";
+    const DMY = new CalEventHelper(GREGORIAN, true);
+    const start: CalDate = {
+        year: 1400,
+        month: 1,
+        day: 20,
+    };
+    const end: CalDate = {
+        year: 1400,
+        month: 1,
+        day: 28,
+    };
+    expect(dateString(start, GREGORIAN, end, "DD-MMM-Y")).toEqual("February 20th—28th, 1400");
+});
+
+test("Repeating: Same day every month", () => {
+    GREGORIAN.dateFormat = "DD-MMM-Y";
+    const start: Partial<CalDate> = {
+        day: 20,
+    };
+    expect(dateString(start, GREGORIAN, undefined, "DD-MMM-Y")).toEqual("20th of every month");
+});
+
+test("Repeating interval: Same month/day every year", () => {
+    GREGORIAN.dateFormat = "DD-MMM-Y";
+    const start: Partial<CalDate> = {
+        month: 1,
+        day: 20,
+    };
+    expect(dateString(start, GREGORIAN, undefined, "DD-MMM-Y")).toEqual("February 20th of every year");
+});
+
+test("Repeating interval: Same range of days every month", () => {
+    GREGORIAN.dateFormat = "DD-MMM-Y";
+    const start: Partial<CalDate> = {
+        day: 20,
+    };
+    const end: Partial<CalDate> = {
+        day: 24,
+    };
+    expect(dateString(start, GREGORIAN, end, "DD-MMM-Y")).toEqual("20th—24th of every month");
+});
+
+
+test("Repeating interval: Same month/day range every year", () => {
+    GREGORIAN.dateFormat = "DD-MMM-Y";
+    const start: Partial<CalDate> = {
+        month: 1,
+        day: 20,
+    };
+    const end: Partial<CalDate> = {
+        month: 1,
+        day: 24,
+    };
+    expect(dateString(start, GREGORIAN, end, "DD-MMM-Y")).toEqual("February 20th—24th of every year");
+});
+
+test("Repeating interval: Same cross-month range of days every year", () => {
+    GREGORIAN.dateFormat = "DD-MMM-Y";
+    const start: Partial<CalDate> = {
+        month: 1,
+        day: 20,
+    };
+    const end: Partial<CalDate> = {
+        month: 2,
+        day: 24,
+    };
+    expect(dateString(start, GREGORIAN, end, "DD-MMM-Y")).toEqual("February 20th — March 24th of every year");
 });

--- a/test/event.parseFcString.gregorian.test.ts
+++ b/test/event.parseFcString.gregorian.test.ts
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment happy-dom
  */
-import { CalEvent } from "../src/@types";
+import { CalDate, CalEvent } from "../src/@types";
 import { CalEventHelper, ParseDate } from "../src/events/event.helper";
-import { sortEventList } from "../src/utils/functions";
+import { dateString, sortEventList } from "../src/utils/functions";
 import { PRESET_CALENDARS } from "../src/utils/presets";
 import { vi, test, expect } from "vitest";
 
@@ -81,6 +81,15 @@ test("Parse February: Leap year", () => {
     expect(helper.parseCalDateString("1700-Feb-29", file)).toBeNull();
     expect(helper.parseCalDateString("1800-Feb-29", file)).toBeNull();
     expect(helper.parseCalDateString("1900-Feb-29", file)).toBeNull();
+
+    const formatThis = {
+        ...expected,
+        year: 1996,
+    } as CalDate;
+
+    expect(dateString(formatThis, GREGORIAN)).toEqual("1996-02-29");
+    expect(dateString(formatThis, GREGORIAN, undefined, 'D MMMM, YYYY')).toEqual("29 February, 1996");
+    expect(dateString(formatThis, GREGORIAN, undefined, 'YYYY-MMM-DD')).toEqual("1996-Feb-29");
 });
 test("Parse March", () => {
     const expected: ParseDate = {

--- a/test/event.parseFcString.harptos.test.ts
+++ b/test/event.parseFcString.harptos.test.ts
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment happy-dom
  */
-import { CalEvent } from "../src/@types";
+import { CalDate, CalEvent } from "../src/@types";
 import { CalEventHelper, ParseDate } from "../src/events/event.helper";
-import { sortEventList } from "../src/utils/functions";
+import { dateString, sortEventList } from "../src/utils/functions";
 import { PRESET_CALENDARS } from "../src/utils/presets";
 import { vi, test, expect } from "vitest";
 
@@ -36,6 +36,11 @@ const file = {
 // 15 | 16 |  - | Feast of the Moon
 // 16 | 17 | 12 | Nightal
 
+test("Preset padding", () => {
+    expect(HARPTOS.static.padDays).toEqual(2);
+    expect(HARPTOS.static.padMonths).toEqual(2);
+});
+
 test("daysForMonth", () => {
     expect(helper.daysForMonth(0, 1499)).toEqual(30);
     expect(helper.daysForMonth(1, 1499)).toEqual(1);
@@ -54,11 +59,16 @@ test("Parse Harptos: 1499-01, Hammer", () => {
         day: 1,
         order: "",
     };
+    // em dash and en dash
     expect(helper.parseCalDateString("1499", file)).toEqual(expected);
-    expect(helper.parseCalDateString("1499-01", file)).toEqual(expected);
-    expect(helper.parseCalDateString("1499-01-01", file)).toEqual(expected);
+    expect(helper.parseCalDateString("1499—01", file)).toEqual(expected);
+    expect(helper.parseCalDateString("1499–01-01", file)).toEqual(expected);
     expect(helper.parseCalDateString("1499-Hammer", file)).toEqual(expected);
     expect(helper.parseCalDateString("1499-Hammer-01", file)).toEqual(expected);
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Hammer-01");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("1 Hammer (Deepwinter), 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-01-01");
 });
 //  1 |  2 |  - | Midwinter
 test("Parse Harptos: 1499-02, Midwinter", () => {
@@ -74,6 +84,11 @@ test("Parse Harptos: 1499-02, Midwinter", () => {
     expect(helper.parseCalDateString("1499-Midwinter-01", file)).toEqual(
         expected
     );
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Midwinter");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("Midwinter, 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-02-01");
+
     // Midwinter has only one day...
     expect(helper.parseCalDateString("1499-02-03", file)).toBeNull();
 });
@@ -91,6 +106,10 @@ test("Parse Harptos: 1499-03, Alturiak", () => {
     expect(helper.parseCalDateString("1499-Alturiak-01", file)).toEqual(
         expected
     );
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Alturiak-01");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("1 Alturiak (The Claw of Winter), 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-03-01");
 });
 //  3 |  4 |  3 | Ches
 //  4 |  5 |  4 | Tarsakh
@@ -111,6 +130,10 @@ test("Parse Harptos: 1499-06, Greengrass", () => {
         expected
     );
 
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Greengrass");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("Greengrass, 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-06-01");
+
     const ordered: ParseDate = { ...expected, order: "03" };
     expect(helper.parseCalDateString("1499-Greengrass-01-03", file)).toEqual(
         ordered
@@ -130,6 +153,10 @@ test("Parse Harptos: 1499-06, Mirtul", () => {
     expect(helper.parseCalDateString("1499-07-01", file)).toEqual(expected);
     expect(helper.parseCalDateString("1499-Mir", file)).toEqual(expected);
     expect(helper.parseCalDateString("1499-Mirtul-01", file)).toEqual(expected);
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Mirtul-01");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("1 Mirtul (The Melting), 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-07-01");
 });
 //  7 |  8 |  6 | Kythorn
 //  8 |  9 |  7 | Flamerule
@@ -147,6 +174,10 @@ test("Parse Harptos: 1499-09, Midsummer", () => {
     expect(helper.parseCalDateString("1499-Midsummer-01", file)).toEqual(
         expected
     );
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Midsummer");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("Midsummer, 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-10-01");
 
     const ordered: ParseDate = { ...expected, order: "03" };
     expect(helper.parseCalDateString("1499-Midsummer-01-03", file)).toEqual(
@@ -173,6 +204,10 @@ test("Parse Harptos: 1372-Shieldmeet", () => {
         ordered
     );
 
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1372-Shieldmeet");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("Shieldmeet, 1372");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1372-10-02");
+
     // Shieldmeet is a leapday (not in 1499)
     expect(helper.parseCalDateString("1499-10-02", file)).toBeNull();
 });
@@ -190,6 +225,10 @@ test("Parse Harptos: 1499-11, Eleasis", () => {
     expect(helper.parseCalDateString("1499-Eleasis-01", file)).toEqual(
         expected
     );
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Eleasis-01");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("1 Eleasis (Highsun), 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-11-01");
 });
 // 11 | 12 |  9 | Eleint
 // 12 | 13 |  - | Highharvestide
@@ -206,6 +245,10 @@ test("Parse Harptos: 1499-13, Highharvestide", () => {
     expect(helper.parseCalDateString("1499-Highharvestide-01", file)).toEqual(
         expected
     );
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Highharvestide");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("Highharvestide, 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-13-01");
 });
 // 13 | 14 | 10 | Marpenoth
 test("Parse Harptos: 1499-14, Marpenoth", () => {
@@ -221,6 +264,10 @@ test("Parse Harptos: 1499-14, Marpenoth", () => {
     expect(helper.parseCalDateString("1499-Marpenoth-01", file)).toEqual(
         expected
     );
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-Marpenoth-01");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("1 Marpenoth (Leaffall), 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-14-01");
 });
 // 14 | 15 | 11 | Uktar
 // 15 | 16 |  - | Feast of the Moon
@@ -234,9 +281,15 @@ test("Parse Harptos: 1499-15, Feast of the Moon", () => {
     expect(helper.parseCalDateString("1499-16", file)).toEqual(expected);
     expect(helper.parseCalDateString("1499-16-01", file)).toEqual(expected);
     expect(helper.parseCalDateString("1499-The Feast", file)).toEqual(expected);
+    expect(helper.parseCalDateString("1499-FeastOfTheMoon", file)).toEqual(expected); // short name
     expect(
         helper.parseCalDateString("1499-The Feast of the Moon-01", file)
     ).toEqual(expected);
+
+    expect(dateString(expected as CalDate, HARPTOS)).toEqual("1499-FeastOfTheMoon");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'D MMMM, YYYY')).toEqual("The Feast of the Moon, 1499");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MMMM-DD')).toEqual("1499-The Feast of the Moon");
+    expect(dateString(expected as CalDate, HARPTOS, undefined, 'YYYY-MM-DD')).toEqual("1499-16-01");
 });
 // 16 | 17 | 12 | Nightal
 

--- a/test/event.parseFunctions.test.ts
+++ b/test/event.parseFunctions.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { Loc, Pos } from "obsidian";
-import { CalEvent } from "../src/@types";
+import { CalEvent, Calendar } from "../src/@types";
 import { CalEventHelper, ParseDate } from "../src/events/event.helper";
 import { PRESET_CALENDARS } from "../src/utils/presets";
 import { test, expect } from "vitest";
@@ -10,7 +10,7 @@ import { test, expect } from "vitest";
 import Moment from "moment";
 Object.defineProperty(window, "moment", { value: Moment });
 
-const GREGORIAN = PRESET_CALENDARS.find((p) => p.name == "Gregorian Calendar");
+const GREGORIAN: Calendar = PRESET_CALENDARS.find((p) => p.name == "Gregorian Calendar");
 const gregorian = new CalEventHelper(GREGORIAN, true);
 
 const file = {
@@ -27,6 +27,11 @@ const position: Pos = {
     end: loc,
 };
 
+test("Preset padding", () => {
+    expect(GREGORIAN.static.padDays).toEqual(2);
+    expect(GREGORIAN.static.padMonths).toEqual(2);
+});
+
 test("Bad Year", () => {
     expect(gregorian.parseCalDateString("", file)).toBeNull();
 });
@@ -39,8 +44,6 @@ test("Timestamp", () => {
         order: "",
     };
 
-    expect(gregorian.padDays).toEqual(2);
-    expect(gregorian.padMonth).toEqual(2);
     expect(gregorian.parsedToTimestamp(expected)).toEqual({
         timestamp: 19660301,
         order: "",


### PR DESCRIPTION
## Pull Request Description

Add a method to the API to format a partial CalDate (with an optional end CalDate) to a string.

## Changes Proposed

- Add method to API
- Consolidate date -> string parsing into a function that can be used by both API and event helper 

## Additional Notes

- Added a test for these alternate range strings
- Moved computation of padding for days/months to static calendar data (updated when month is changed)

## Outstanding questions: 

You had range expressed always in "MMM D, YYYY" format. I don't know how you want to resolve consolidated range strings with the date format specified by the calendar.

BEGIN_COMMIT_OVERRIDE
fix: Better date formatting behavior
END_COMMIT_OVERRIDE